### PR TITLE
Bepsi classic reconnect

### DIFF
--- a/src/listeners/lightningL.js
+++ b/src/listeners/lightningL.js
@@ -23,6 +23,12 @@ const startLightningListener = async () => {
     pinNo = messageStr.split("-")[0];
     dispenseFromPayments(pinNo, "sats");
   });
+  
+ ws.onclose = (event) => {
+    const reconnectInterval = 60000; // 60000 milliseconds = 1 minute
+    console.log("Connection cannot be established. Reconnecting in 1 minute");
+    setTimeout(startLightningListener, reconnectInterval);
+};
 
   // Event listener for handling errors
   await ws.on("error", function error(err) {


### PR DESCRIPTION
This pull request proposes urgently needed code that:

- prevents the pi from dying when the websockets is interrupted (e.g. internet outage or a restart on the remote server side)
- attempts to reconnect once per minute until the websockets has been reestablished